### PR TITLE
[Paris] Set page size to 24

### DIFF
--- a/storescraper/stores/paris.py
+++ b/storescraper/stores/paris.py
@@ -19,6 +19,7 @@ from storescraper import banner_sections as bs
 
 class Paris(Store):
     USER_AGENT = 'solotodobot'
+    RESULTS_PER_PAGE = 24
 
     category_paths = [
         ['electro/television', ['Television'], 'Electro > Televisión', 1],
@@ -221,8 +222,9 @@ class Paris(Store):
                 if page > 300:
                     raise Exception('Page overflow: ' + category_path)
 
-                category_url = 'https://www.paris.cl/{}/?sz=24&start={}' \
-                               ''.format(category_path, page * 24)
+                category_url = 'https://www.paris.cl/{}/?sz={}&start={}' \
+                               ''.format(category_path, cls.RESULTS_PER_PAGE,
+                                         page * cls.RESULTS_PER_PAGE)
                 print(category_url)
                 response = session.get(category_url)
 
@@ -258,7 +260,7 @@ class Paris(Store):
                     product_entries[product_url].append({
                         'category_weight': category_weight,
                         'section_name': section_name,
-                        'value': 24 * page + idx + 1,
+                        'value': cls.RESULTS_PER_PAGE * page + idx + 1,
                     })
 
                 page += 1
@@ -277,8 +279,9 @@ class Paris(Store):
             if page > 40:
                 raise Exception('Page overflow')
 
-            search_url = 'https://www.paris.cl/search?q={}&sz=24&start={}' \
-                .format(keyword, page * 24)
+            search_url = 'https://www.paris.cl/search?q={}&sz={}&start={}' \
+                .format(keyword, cls.RESULTS_PER_PAGE,
+                        page * cls.RESULTS_PER_PAGE)
 
             soup = BeautifulSoup(session.get(search_url).text, 'html.parser')
             containers = soup.findAll('li', 'flex-item-products')

--- a/storescraper/stores/paris.py
+++ b/storescraper/stores/paris.py
@@ -221,8 +221,8 @@ class Paris(Store):
                 if page > 300:
                     raise Exception('Page overflow: ' + category_path)
 
-                category_url = 'https://www.paris.cl/{}/?sz=40&start={}' \
-                               ''.format(category_path, page * 40)
+                category_url = 'https://www.paris.cl/{}/?sz=24&start={}' \
+                               ''.format(category_path, page * 24)
                 print(category_url)
                 response = session.get(category_url)
 
@@ -258,7 +258,7 @@ class Paris(Store):
                     product_entries[product_url].append({
                         'category_weight': category_weight,
                         'section_name': section_name,
-                        'value': 40 * page + idx + 1,
+                        'value': 24 * page + idx + 1,
                     })
 
                 page += 1
@@ -277,8 +277,8 @@ class Paris(Store):
             if page > 40:
                 raise Exception('Page overflow')
 
-            search_url = 'https://www.paris.cl/search?q={}&sz=40&start={}' \
-                .format(keyword, page * 40)
+            search_url = 'https://www.paris.cl/search?q={}&sz=24&start={}' \
+                .format(keyword, page * 24)
 
             soup = BeautifulSoup(session.get(search_url).text, 'html.parser')
             containers = soup.findAll('li', 'flex-item-products')

--- a/storescraper/stores/paris_fast.py
+++ b/storescraper/stores/paris_fast.py
@@ -51,8 +51,9 @@ class ParisFast(Store):
                 if page > 150:
                     raise Exception('Page overflow:' + category_path)
 
-                category_url = 'https://www.paris.cl/{}/?start={}&sz=24'\
-                    .format(category_path, page * 24)
+                category_url = 'https://www.paris.cl/{}/?start={}&sz={}'\
+                    .format(category_path, page * Paris.RESULTS_PER_PAGE.
+                            Paris.RESULTS_PER_PAGE)
                 print(category_url)
                 response = session.get(category_url)
 
@@ -90,7 +91,8 @@ class ParisFast(Store):
                         product_to_update = product
 
                     product_to_update.positions.append(
-                        (section_name, 24 * page + idx + 1))
+                        (section_name,
+                         Paris.RESULTS_PER_PAGE * page + idx + 1))
 
                 page += 1
 

--- a/storescraper/stores/paris_fast.py
+++ b/storescraper/stores/paris_fast.py
@@ -51,8 +51,8 @@ class ParisFast(Store):
                 if page > 150:
                     raise Exception('Page overflow:' + category_path)
 
-                category_url = 'https://www.paris.cl/{}/?start={}&sz=40'\
-                    .format(category_path, page * 40)
+                category_url = 'https://www.paris.cl/{}/?start={}&sz=24'\
+                    .format(category_path, page * 24)
                 print(category_url)
                 response = session.get(category_url)
 
@@ -90,7 +90,7 @@ class ParisFast(Store):
                         product_to_update = product
 
                     product_to_update.positions.append(
-                        (section_name, 40 * page + idx + 1))
+                        (section_name, 24 * page + idx + 1))
 
                 page += 1
 


### PR DESCRIPTION
This PR solves a potential issue in `Paris.cl` where the page size is limited to 24 or less (doesn't support a size of 40 anymore). This means that currently you have an issue where some products are not being scraped, resulting in a loss of 16 products per page. 